### PR TITLE
Add metadata.dergigi.com to live instances

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,7 @@ Minimial javascript dependencies. no JS frameworks. no state management tools.
 ## Live instances
 
 - https://metadata.nostr.com/
+- https://metadata.dergigi.com/
 
 ## Features
 


### PR DESCRIPTION
Running a slightly modified version, as per #10:

- https://metadata.dergigi.com/